### PR TITLE
Introduce checkpointers with tier-1 encodings (CLOSED, FULL, CARRY)

### DIFF
--- a/include/simdb/apps/argos/ArgosCollector.hpp
+++ b/include/simdb/apps/argos/ArgosCollector.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "simdb/apps/App.hpp"
+#include "simdb/apps/argos/Checkpointer.hpp"
 #include "simdb/apps/argos/EntryPoint.hpp"
 #include "simdb/apps/argos/EnumInspector.hpp"
 #include "simdb/apps/argos/PipelineStagerInterface.hpp"
@@ -389,8 +390,7 @@ private:
         /// Must be called from main thread
         void setScalarDataType(uint16_t cid)
         {
-            // TODO: checkpointers
-            (void)cid;
+            checkpointers_[cid] = std::make_unique<ScalarCheckpointer>(heartbeat_);
             ++num_scalars_;
         }
 
@@ -399,15 +399,11 @@ private:
         {
             if (sparse)
             {
-                // TODO: checkpointers
-                (void)cid;
-                (void)capacity;
+                checkpointers_[cid] = std::make_unique<SparseContainerCheckpointer>(heartbeat_, capacity);
                 ++num_sparses_;
             } else
             {
-                // TODO: checkpointers
-                (void)cid;
-                (void)capacity;
+                checkpointers_[cid] = std::make_unique<ContigContainerCheckpointer>(heartbeat_, capacity);
                 ++num_contigs_;
             }
         }
@@ -421,15 +417,194 @@ private:
         /// Must be called from main thread
         void writeMetaOnPostTeardown(DatabaseManager* db_mgr)
         {
-            // TODO
-            (void)db_mgr;
+            writeShowInUI_(db_mgr);
+            writeQueueMaxSizes_(db_mgr);
         }
 
     private:
         pipeline::PipelineAction run_(bool) override
         {
-            // TODO (until this is filled in, the rest of the pipeline has nothing to do)
-            return pipeline::PipelineAction::SLEEP;
+            auto action = pipeline::PipelineAction::SLEEP;
+
+            LedgerPtr ledger;
+            while (main_input_queue_->try_pop(ledger))
+            {
+                auto window_id = ledger->getWindowId();
+
+                auto scalars = ledger->releaseScalarEntries();
+                for (auto& scalar : scalars)
+                {
+                    auto cid = scalar.cid;
+                    auto data = std::move(scalar.scalar_bytes);
+                    checkpointers_.at(cid)->createCheckpoint(window_id, std::move(data));
+                }
+
+                auto contigs = ledger->releaseContigEntries();
+                for (auto& contig : contigs)
+                {
+                    auto cid = contig.cid;
+                    auto data = std::move(contig.contig_bin_bytes);
+                    checkpointers_.at(cid)->createCheckpoint(window_id, std::move(data));
+                    updateContainerMaxSize_(cid, detail::getContainerSize(data));
+                }
+
+                auto sparses = ledger->releaseSparseEntries();
+                for (auto& sparse : sparses)
+                {
+                    auto cid = sparse.cid;
+                    auto data = std::move(sparse.sparse_bin_bytes);
+                    checkpointers_.at(cid)->createCheckpoint(window_id, std::move(data));
+                    updateContainerMaxSize_(cid, detail::getContainerSize(data));
+                }
+
+                for (const auto cid : ledger->getClosedCIDs())
+                {
+                    checkpointers_.at(cid)->closeRecord(window_id);
+                }
+
+                CollectionEntries to_send;
+                auto sim_time = ledger->getSimTime();
+                to_send.sim_time = sim_time;
+
+                const auto multi_clock = clock_ids_.size() > 1;
+                for (auto& [cid, checkpointer] : checkpointers_)
+                {
+                    if (multi_clock && !checkpointer->participatedInWindow(window_id))
+                    {
+                        continue;
+                    }
+
+                    auto entries = checkpointer->encodeForPipeline(window_id, sim_time, cid);
+                    for (auto& entry : entries)
+                    {
+                        cids_with_data_.insert(cid);
+                        to_send.entries.emplace_back(std::move(entry));
+                        if (const auto clk_it = collectable_clock_ids_.find(cid);
+                            clk_it != collectable_clock_ids_.end())
+                        {
+                            to_send.clock_ids.insert(clk_it->second);
+                        }
+                    }
+                }
+
+                if (!to_send.entries.empty())
+                {
+                    data_output_queue_->emplace(std::move(to_send));
+                }
+
+                action = pipeline::PipelineAction::PROCEED;
+            }
+
+            return action;
+        }
+
+        void updateContainerMaxSize_(uint16_t cid, uint16_t size)
+        {
+            auto it = container_max_sizes_.find(cid);
+            if (it == container_max_sizes_.end())
+            {
+                container_max_sizes_.emplace(cid, size);
+            } else
+            {
+                it->second = std::max(it->second, size);
+            }
+        }
+
+        // Set ShowInUI=1 for all the collectables that actually collected data
+        void writeShowInUI_(DatabaseManager* db_mgr) const
+        {
+            const std::vector<int> valid_cids(cids_with_data_.begin(), cids_with_data_.end());
+            if (!valid_cids.empty())
+            {
+                std::ostringstream oss;
+                oss << "UPDATE CollectableTreeNodes SET ShowInUI=1 WHERE CID IN (";
+
+                bool comma = false;
+                for (const auto cid : valid_cids)
+                {
+                    if (comma)
+                    {
+                        oss << ",";
+                    }
+                    oss << cid;
+                    comma = true;
+                }
+                oss << ")";
+                db_mgr->EXECUTE(oss.str());
+            }
+
+            auto query = db_mgr->createQuery("CollectableTreeNodes");
+            query->addConstraintForInt("CID", SetConstraints::NOT_IN_SET, valid_cids);
+
+            struct CID_Info
+            {
+                std::string path;
+                std::string type;
+
+                CID_Info(const std::string& path, const std::string& type) :
+                    path(path),
+                    type(type)
+                {
+                }
+            };
+
+            std::string path;
+            query->select("FullPath", path);
+
+            std::string type;
+            query->select("TypeName", type);
+
+            std::vector<CID_Info> cid_infos;
+            auto results = query->getResultSet();
+            while (results.getNextRecord())
+            {
+                cid_infos.emplace_back(path, type);
+            }
+
+            if (!cid_infos.empty())
+            {
+                std::ostringstream oss;
+                oss << "No data was ever collected for the following collectables, and will not be shown in Argos:\n";
+                size_t leftcol_w = 0;
+                for (const auto& info : cid_infos)
+                {
+                    leftcol_w = std::max(leftcol_w, info.path.size());
+                }
+
+                leftcol_w += 12;
+                for (const auto& info : cid_infos)
+                {
+                    oss << std::left << std::setw(leftcol_w) << info.path;
+                    if (auto idx = info.type.find("_sparse"); idx != std::string::npos)
+                    {
+                        auto base_type = info.type.substr(0, idx);
+                        oss << "(Sparse container of '" << base_type << "')";
+                    } else if (auto idx = info.type.find("_contig"); idx != std::string::npos)
+                    {
+                        auto base_type = info.type.substr(0, idx);
+                        oss << "(Contig container of '" << base_type << "')";
+                    } else
+                    {
+                        oss << "(" << info.type << ")";
+                    }
+                    oss << "\n";
+                }
+
+                auto warning = oss.str();
+                warning.pop_back();
+
+                db_mgr->INSERT(SQL_TABLE("Notifications"), SQL_COLUMNS("NotifStr", "NotifType"),
+                               SQL_VALUES(warning, (int)NotifType::WARNING));
+            }
+        }
+
+        void writeQueueMaxSizes_(DatabaseManager* db_mgr) const
+        {
+            auto inserter = db_mgr->prepareINSERT(SQL_TABLE("QueueMaxSizes"));
+            for (const auto& [cid, max_size] : container_max_sizes_)
+            {
+                inserter->createRecordWithColValues((int)cid, (int)max_size);
+            }
         }
 
         const size_t heartbeat_;
@@ -441,6 +616,7 @@ private:
         std::unordered_set<uint32_t> clock_ids_;
         std::unordered_set<uint16_t> cids_with_data_;
 
+        std::unordered_map<uint16_t, std::unique_ptr<CollectableCheckpointer>> checkpointers_;
         std::unordered_map<uint16_t, uint16_t> container_max_sizes_;
 
         size_t num_scalars_ = 0;

--- a/include/simdb/apps/argos/Checkpoint.hpp
+++ b/include/simdb/apps/argos/Checkpoint.hpp
@@ -1,0 +1,543 @@
+// <Checkpoint.hpp> -*- C++ -*-
+
+#pragma once
+
+#include "simdb/Exceptions.hpp"
+#include "simdb/apps/argos/CheckpointDeltas.hpp"
+#include "simdb/apps/argos/CollectedData.hpp"
+#include "simdb/utils/ValidValue.hpp"
+
+namespace simdb::argos {
+
+//! Encodings that C++ and python agree on. The python deserializers interpret
+//! collected data using the header:
+//!
+//!   [uint16_t cid]     // collectable ID
+//!   [uint8_t action]   // encoding
+//!
+//! See CheckpointEncodings.hpp for full action / byte layout documentation.
+enum class Action : uint8_t {
+    // Tier 1: 0x00–0x0F — lifecycle / common (scalars + all collectables)
+    CLOSED = 0x00,
+    FULL = 0x01,
+    CARRY = 0x02,
+    // 0x03–0x0F reserved
+
+    // Tier 2: 0x10–0x1F — any-container (identical wire for contig & sparse)
+    CONTAINER_SWAP = 0x10,
+    CONTAINER_MULTI_SWAP = 0x11,
+    // 0x12–0x1F reserved
+
+    // Tier 3: 0x20–0x2F — contig-specific (FIFO queue semantics)
+    CONTIG_ARRIVE = 0x20,
+    CONTIG_DEPART = 0x21,
+    CONTIG_BOOKENDS = 0x22,
+    CONTIG_MIMO = 0x23,
+    // 0x24–0x2F reserved
+
+    // Tier 4: 0x30–0x3F — sparse-specific (explicit bin indices)
+    SPARSE_REMOVE = 0x30,
+    SPARSE_ADD = 0x31,
+    SPARSE_MULTI_REMOVE = 0x32,
+    // 0x33–0x3F reserved
+};
+
+//! \class CollectableCheckpoint
+class CollectableCheckpoint
+{
+public:
+    /// Destroys this checkpoint node.
+    virtual ~CollectableCheckpoint() = default;
+
+    /// Returns the previous checkpoint in the chain, or nullptr.
+    CollectableCheckpoint* getPrev() const { return prev_.get(); }
+
+    /// Returns the next checkpoint in the chain, or nullptr.
+    CollectableCheckpoint* getNext() const { return next_; }
+
+    /// Returns the collection window that created this checkpoint.
+    uint64_t getWindowID() const { return window_id_; }
+
+    /// Drops the link to the previous checkpoint.
+    void detachPrev() { prev_.reset(); }
+
+    /// Returns the shared_ptr to the previous checkpoint, if any.
+    const std::shared_ptr<CollectableCheckpoint>& getPrevShared() const { return prev_; }
+
+protected:
+    /// Links \p prev to this node and stores \p window_id.
+    CollectableCheckpoint(std::shared_ptr<CollectableCheckpoint> prev, uint64_t window_id) :
+        prev_(prev),
+        window_id_(window_id)
+    {
+        if (prev_)
+        {
+            prev_->next_ = this;
+        }
+    }
+
+    /// Returns true if a CLOSED event occurred between \p data_prev and \p self.
+    template <typename CheckpointT>
+    static bool closedSincePrevDataCheckpoint_(const CheckpointT* self, const CheckpointT* data_prev)
+    {
+        if (!data_prev)
+        {
+            return false;
+        }
+        const CheckpointT* checkpoint = self->prev();
+        while (checkpoint && checkpoint != data_prev)
+        {
+            if (checkpoint->isClosedEvent())
+            {
+                return true;
+            }
+            checkpoint = checkpoint->prev();
+        }
+        return false;
+    }
+
+    std::shared_ptr<CollectableCheckpoint> prev_;
+    CollectableCheckpoint* next_ = nullptr;
+    const uint64_t window_id_;
+};
+
+class ScalarCheckpoint final : public CollectableCheckpoint
+{
+public:
+    /// Creates a data checkpoint holding a full scalar snapshot.
+    ScalarCheckpoint(std::shared_ptr<ScalarCheckpoint> prev, uint64_t window_id, const std::vector<char>& full_bytes) :
+        CollectableCheckpoint(prev, window_id),
+        full_bytes_(full_bytes)
+    {
+    }
+
+    /// Creates a lifecycle checkpoint recording a close transition.
+    ScalarCheckpoint(std::shared_ptr<ScalarCheckpoint> prev, uint64_t window_id, bool switched_to_closed) :
+        CollectableCheckpoint(prev, window_id),
+        lifecycle_change_(switched_to_closed)
+    {
+    }
+
+    /// Returns the previous scalar checkpoint in the chain.
+    ScalarCheckpoint* prev() { return static_cast<ScalarCheckpoint*>(getPrev()); }
+
+    /// Returns the previous scalar checkpoint in the chain.
+    const ScalarCheckpoint* prev() const { return static_cast<const ScalarCheckpoint*>(getPrev()); }
+
+    /// Returns the next scalar checkpoint in the chain.
+    ScalarCheckpoint* next() { return static_cast<ScalarCheckpoint*>(getNext()); }
+
+    /// Returns true when this node holds collected bytes rather than a lifecycle flag.
+    bool isDataCheckpoint() const { return !lifecycle_change_.isValid(); }
+
+    /// Returns true when this node records a transition to closed.
+    bool isClosedEvent() const { return lifecycle_change_.isValid() && lifecycle_change_.getValue(); }
+
+    /// Returns true for any lifecycle (close) checkpoint.
+    bool isLifecycleEvent() const { return lifecycle_change_.isValid(); }
+
+    /// Encodes an unconditional FULL snapshot for heartbeat or absent-CID refresh.
+    std::unique_ptr<CollectedData> encodeSnapshotForPipeline(uint16_t cid) const
+    {
+        auto encoded = std::make_unique<CollectedData>(cid);
+        auto& buf = encoded->getBuffer();
+        buf.append(Action::FULL);
+        buf.append(full_bytes_);
+        return encoded;
+    }
+
+    /// Encodes CLOSED, FULL, or CARRY by diffing against the prior data checkpoint.
+    std::unique_ptr<CollectedData> encodeForPipeline(uint16_t cid, bool force_snapshot)
+    {
+        if (lifecycle_change_.isValid())
+        {
+            return encodeLifecycleEvt_(cid);
+        }
+
+        if (force_snapshot)
+        {
+            return encodeFull_(cid);
+        }
+
+        const auto* data_prev = prevDataCheckpoint_();
+        if (!data_prev)
+        {
+            return encodeFull_(cid);
+        }
+
+        if (data_prev->full_bytes_ != full_bytes_)
+        {
+            return encodeFull_(cid);
+        }
+
+        if (closedSincePrevDataCheckpoint_(this, data_prev))
+        {
+            return encodeFull_(cid);
+        }
+
+        return encodeDelta_(cid);
+    }
+
+private:
+    /// Walks backward to the nearest prior data checkpoint.
+    const ScalarCheckpoint* prevDataCheckpoint_() const
+    {
+        const auto* checkpoint = prev();
+        while (checkpoint && !checkpoint->isDataCheckpoint())
+        {
+            checkpoint = checkpoint->prev();
+        }
+        return checkpoint;
+    }
+
+    /// Encodes a CLOSED lifecycle wire record.
+    std::unique_ptr<CollectedData> encodeLifecycleEvt_(uint16_t cid)
+    {
+        assert(lifecycle_change_.isValid() && lifecycle_change_.getValue());
+        auto encoded = std::make_unique<CollectedData>(cid);
+        encoded->getBuffer().append(Action::CLOSED);
+        return encoded;
+    }
+
+    /// Encodes a FULL snapshot of the current scalar bytes.
+    std::unique_ptr<CollectedData> encodeFull_(uint16_t cid)
+    {
+        assert(!full_bytes_.empty());
+        auto encoded = std::make_unique<CollectedData>(cid);
+        auto& buf = encoded->getBuffer();
+        buf.append(Action::FULL);
+        buf.append(full_bytes_);
+        return encoded;
+    }
+
+    /// Encodes CARRY when bytes are unchanged since the prior data checkpoint.
+    std::unique_ptr<CollectedData> encodeDelta_(uint16_t cid)
+    {
+        const auto* data_prev = prevDataCheckpoint_();
+        assert(data_prev && data_prev->full_bytes_ == full_bytes_ && !full_bytes_.empty());
+        (void)data_prev;
+        auto encoded = std::make_unique<CollectedData>(cid);
+        auto& buf = encoded->getBuffer();
+        buf.append(Action::CARRY);
+        return encoded;
+    }
+
+    std::vector<char> full_bytes_;
+    ValidValue<bool> lifecycle_change_;
+};
+
+class ContigContainerCheckpoint : public CollectableCheckpoint
+{
+public:
+    /// Creates a data checkpoint holding a full contig container snapshot.
+    ContigContainerCheckpoint(std::shared_ptr<ContigContainerCheckpoint> prev, uint64_t window_id,
+                              const std::vector<std::vector<char>>& full_bytes) :
+        CollectableCheckpoint(prev, window_id),
+        full_bytes_(full_bytes)
+    {
+    }
+
+    /// Creates a lifecycle checkpoint recording a close transition.
+    ContigContainerCheckpoint(std::shared_ptr<ContigContainerCheckpoint> prev, uint64_t window_id,
+                              bool switched_to_closed) :
+        CollectableCheckpoint(prev, window_id),
+        lifecycle_change_(switched_to_closed)
+    {
+    }
+
+    /// Returns the previous contig checkpoint in the chain.
+    ContigContainerCheckpoint* prev() { return static_cast<ContigContainerCheckpoint*>(getPrev()); }
+
+    /// Returns the previous contig checkpoint in the chain.
+    const ContigContainerCheckpoint* prev() const { return static_cast<const ContigContainerCheckpoint*>(getPrev()); }
+
+    /// Returns the next contig checkpoint in the chain.
+    ContigContainerCheckpoint* next() { return static_cast<ContigContainerCheckpoint*>(getNext()); }
+
+    /// Returns true when this node holds collected bytes rather than a lifecycle flag.
+    bool isDataCheckpoint() const { return !lifecycle_change_.isValid(); }
+
+    /// Returns true when this node records a transition to closed.
+    bool isClosedEvent() const { return lifecycle_change_.isValid() && lifecycle_change_.getValue(); }
+
+    /// Returns true for any lifecycle (close) checkpoint.
+    bool isLifecycleEvent() const { return lifecycle_change_.isValid(); }
+
+    /// Encodes an unconditional FULL snapshot for heartbeat or absent-CID refresh.
+    std::unique_ptr<CollectedData> encodeSnapshotForPipeline(uint16_t cid) const
+    {
+        assert(isDataCheckpoint());
+        auto encoded = std::make_unique<CollectedData>(cid);
+        auto& buf = encoded->getBuffer();
+        buf.append(Action::FULL);
+        appendContigBins_(buf, full_bytes_);
+        return encoded;
+    }
+
+    /// Encodes CLOSED, FULL, or a contig delta by diffing against the prior data checkpoint.
+    std::unique_ptr<CollectedData> encodeForPipeline(uint16_t cid, bool force_snapshot)
+    {
+        if (lifecycle_change_.isValid())
+        {
+            return encodeLifecycleEvt_(cid);
+        }
+
+        if (force_snapshot)
+        {
+            return encodeFull_(cid);
+        }
+
+        auto* data_prev = prevDataCheckpoint_();
+        if (!data_prev)
+        {
+            return encodeFull_(cid);
+        }
+
+        if (closedSincePrevDataCheckpoint_(this, data_prev))
+        {
+            return encodeFull_(cid);
+        }
+
+        const auto classification = classifyContigChange(data_prev->full_bytes_, full_bytes_);
+        if (classification.kind == ContigDeltaKind::FULL)
+        {
+            return encodeFull_(cid);
+        }
+
+        return encodeDelta_(cid, classification);
+    }
+
+private:
+    /// Walks backward to the nearest prior data checkpoint.
+    const ContigContainerCheckpoint* prevDataCheckpoint_() const
+    {
+        const auto* checkpoint = prev();
+        while (checkpoint && !checkpoint->isDataCheckpoint())
+        {
+            checkpoint = checkpoint->prev();
+        }
+        return checkpoint;
+    }
+
+    /// Maps a contig delta classification to its wire Action byte.
+    static Action contigActionFromKind_(ContigDeltaKind kind)
+    {
+        switch (kind)
+        {
+        case ContigDeltaKind::CARRY:
+            return Action::CARRY;
+        case ContigDeltaKind::FULL:
+            break;
+        default:
+            break;
+        }
+        throw DBException("Invalid contig delta kind");
+    }
+
+    /// Appends the FULL tail for the current contig snapshot to \p buf.
+    void appendFullTail_(StreamBuffer& buf) const { appendContigBins_(buf, full_bytes_); }
+
+    /// Appends contig bins as [count][bin bytes]... to \p buf.
+    static void appendContigBins_(StreamBuffer& buf, const std::vector<std::vector<char>>& bins)
+    {
+        const auto size = countContigElements(bins);
+        buf.append(size);
+        for (uint16_t i = 0; i < size; ++i)
+        {
+            buf.append(bins[i]);
+        }
+    }
+
+    /// Encodes a CLOSED lifecycle wire record.
+    std::unique_ptr<CollectedData> encodeLifecycleEvt_(uint16_t cid)
+    {
+        assert(lifecycle_change_.isValid() && lifecycle_change_.getValue());
+        (void)cid;
+        auto encoded = std::make_unique<CollectedData>(cid);
+        encoded->getBuffer().append(Action::CLOSED);
+        return encoded;
+    }
+
+    /// Encodes a FULL snapshot of the current contig container.
+    std::unique_ptr<CollectedData> encodeFull_(uint16_t cid)
+    {
+        auto encoded = std::make_unique<CollectedData>(cid);
+        auto& buf = encoded->getBuffer();
+        buf.append(Action::FULL);
+        appendFullTail_(buf);
+        return encoded;
+    }
+
+    /// Encodes CARRY when the contig snapshot is unchanged since the prior data checkpoint.
+    std::unique_ptr<CollectedData> encodeDelta_(uint16_t cid, const ContigDeltaClassification& classification)
+    {
+        auto encoded = std::make_unique<CollectedData>(cid);
+        auto& buf = encoded->getBuffer();
+        buf.append(contigActionFromKind_(classification.kind));
+        return encoded;
+    }
+
+    std::vector<std::vector<char>> full_bytes_;
+    ValidValue<bool> lifecycle_change_;
+};
+
+class SparseContainerCheckpoint : public CollectableCheckpoint
+{
+public:
+    /// Creates a data checkpoint holding a full sparse container snapshot.
+    SparseContainerCheckpoint(std::shared_ptr<SparseContainerCheckpoint> prev, uint64_t window_id,
+                              const std::map<uint16_t, std::vector<char>>& full_bytes) :
+        CollectableCheckpoint(prev, window_id),
+        full_bytes_(full_bytes)
+    {
+    }
+
+    /// Creates a lifecycle checkpoint recording a close transition.
+    SparseContainerCheckpoint(std::shared_ptr<SparseContainerCheckpoint> prev, uint64_t window_id,
+                              bool switched_to_closed) :
+        CollectableCheckpoint(prev, window_id),
+        lifecycle_change_(switched_to_closed)
+    {
+    }
+
+    /// Returns the previous sparse checkpoint in the chain.
+    SparseContainerCheckpoint* prev() { return static_cast<SparseContainerCheckpoint*>(getPrev()); }
+
+    /// Returns the previous sparse checkpoint in the chain.
+    const SparseContainerCheckpoint* prev() const { return static_cast<const SparseContainerCheckpoint*>(getPrev()); }
+
+    /// Returns the next sparse checkpoint in the chain.
+    SparseContainerCheckpoint* next() { return static_cast<SparseContainerCheckpoint*>(getNext()); }
+
+    /// Returns true when this node holds collected bytes rather than a lifecycle flag.
+    bool isDataCheckpoint() const { return !lifecycle_change_.isValid(); }
+
+    /// Returns true when this node records a transition to closed.
+    bool isClosedEvent() const { return lifecycle_change_.isValid() && lifecycle_change_.getValue(); }
+
+    /// Returns true for any lifecycle (close) checkpoint.
+    bool isLifecycleEvent() const { return lifecycle_change_.isValid(); }
+
+    /// Encodes an unconditional FULL snapshot for heartbeat or absent-CID refresh.
+    std::unique_ptr<CollectedData> encodeSnapshotForPipeline(uint16_t cid) const
+    {
+        assert(isDataCheckpoint());
+        auto encoded = std::make_unique<CollectedData>(cid);
+        auto& buf = encoded->getBuffer();
+        buf.append(Action::FULL);
+        appendFullTail_(buf);
+        return encoded;
+    }
+
+    /// Encodes CLOSED, FULL, or a sparse delta by diffing against the prior data checkpoint.
+    std::unique_ptr<CollectedData> encodeForPipeline(uint16_t cid, bool force_snapshot)
+    {
+        if (lifecycle_change_.isValid())
+        {
+            return encodeLifecycleEvt_(cid);
+        }
+
+        if (force_snapshot)
+        {
+            return encodeFull_(cid);
+        }
+
+        const auto* data_prev = prevDataCheckpoint_();
+        if (!data_prev)
+        {
+            return encodeFull_(cid);
+        }
+
+        if (closedSincePrevDataCheckpoint_(this, data_prev))
+        {
+            return encodeFull_(cid);
+        }
+
+        const auto classification = classifySparseChange(data_prev->full_bytes_, full_bytes_);
+        if (classification.kind == SparseDeltaKind::FULL)
+        {
+            return encodeFull_(cid);
+        }
+
+        return encodeDelta_(cid, classification);
+    }
+
+private:
+    /// Walks backward to the nearest prior data checkpoint.
+    const SparseContainerCheckpoint* prevDataCheckpoint_() const
+    {
+        const auto* checkpoint = prev();
+        while (checkpoint && !checkpoint->isDataCheckpoint())
+        {
+            checkpoint = checkpoint->prev();
+        }
+        return checkpoint;
+    }
+
+    /// Maps a sparse delta classification to its wire Action byte.
+    static Action sparseActionFromKind_(SparseDeltaKind kind)
+    {
+        switch (kind)
+        {
+        case SparseDeltaKind::CARRY:
+            return Action::CARRY;
+        case SparseDeltaKind::FULL:
+            break;
+        default:
+            break;
+        }
+        throw DBException("Invalid sparse delta kind");
+    }
+
+    /// Appends the FULL tail for the current sparse snapshot to \p buf.
+    void appendFullTail_(StreamBuffer& buf) const { appendSparseBins_(buf, full_bytes_); }
+
+    /// Appends sparse bins as [count][idx][bin bytes]... to \p buf.
+    static void appendSparseBins_(StreamBuffer& buf, const std::map<uint16_t, std::vector<char>>& bins)
+    {
+        const auto size = countSparseElements(bins);
+        buf.append(size);
+        for (const auto& [bin_idx, bin_bytes] : bins)
+        {
+            if (!bin_bytes.empty())
+            {
+                buf.append(bin_idx);
+                buf.append(bin_bytes);
+            }
+        }
+    }
+
+    /// Encodes a CLOSED lifecycle wire record.
+    std::unique_ptr<CollectedData> encodeLifecycleEvt_(uint16_t cid)
+    {
+        assert(lifecycle_change_.isValid() && lifecycle_change_.getValue());
+        (void)cid;
+        auto encoded = std::make_unique<CollectedData>(cid);
+        encoded->getBuffer().append(Action::CLOSED);
+        return encoded;
+    }
+
+    /// Encodes a FULL snapshot of the current sparse container.
+    std::unique_ptr<CollectedData> encodeFull_(uint16_t cid)
+    {
+        auto encoded = std::make_unique<CollectedData>(cid);
+        auto& buf = encoded->getBuffer();
+        buf.append(Action::FULL);
+        appendFullTail_(buf);
+        return encoded;
+    }
+
+    /// Encodes CARRY when the sparse snapshot is unchanged since the prior data checkpoint.
+    std::unique_ptr<CollectedData> encodeDelta_(uint16_t cid, const SparseDeltaClassification& classification)
+    {
+        auto encoded = std::make_unique<CollectedData>(cid);
+        auto& buf = encoded->getBuffer();
+        buf.append(sparseActionFromKind_(classification.kind));
+        return encoded;
+    }
+
+    std::map<uint16_t, std::vector<char>> full_bytes_;
+    ValidValue<bool> lifecycle_change_;
+};
+
+} // namespace simdb::argos

--- a/include/simdb/apps/argos/Checkpoint.hpp
+++ b/include/simdb/apps/argos/Checkpoint.hpp
@@ -17,29 +17,9 @@ namespace simdb::argos {
 //!
 //! See CheckpointEncodings.hpp for full action / byte layout documentation.
 enum class Action : uint8_t {
-    // Tier 1: 0x00–0x0F — lifecycle / common (scalars + all collectables)
     CLOSED = 0x00,
     FULL = 0x01,
     CARRY = 0x02,
-    // 0x03–0x0F reserved
-
-    // Tier 2: 0x10–0x1F — any-container (identical wire for contig & sparse)
-    CONTAINER_SWAP = 0x10,
-    CONTAINER_MULTI_SWAP = 0x11,
-    // 0x12–0x1F reserved
-
-    // Tier 3: 0x20–0x2F — contig-specific (FIFO queue semantics)
-    CONTIG_ARRIVE = 0x20,
-    CONTIG_DEPART = 0x21,
-    CONTIG_BOOKENDS = 0x22,
-    CONTIG_MIMO = 0x23,
-    // 0x24–0x2F reserved
-
-    // Tier 4: 0x30–0x3F — sparse-specific (explicit bin indices)
-    SPARSE_REMOVE = 0x30,
-    SPARSE_ADD = 0x31,
-    SPARSE_MULTI_REMOVE = 0x32,
-    // 0x33–0x3F reserved
 };
 
 //! \class CollectableCheckpoint
@@ -319,21 +299,6 @@ private:
         return checkpoint;
     }
 
-    /// Maps a contig delta classification to its wire Action byte.
-    static Action contigActionFromKind_(ContigDeltaKind kind)
-    {
-        switch (kind)
-        {
-        case ContigDeltaKind::CARRY:
-            return Action::CARRY;
-        case ContigDeltaKind::FULL:
-            break;
-        default:
-            break;
-        }
-        throw DBException("Invalid contig delta kind");
-    }
-
     /// Appends the FULL tail for the current contig snapshot to \p buf.
     void appendFullTail_(StreamBuffer& buf) const { appendContigBins_(buf, full_bytes_); }
 
@@ -371,9 +336,11 @@ private:
     /// Encodes CARRY when the contig snapshot is unchanged since the prior data checkpoint.
     std::unique_ptr<CollectedData> encodeDelta_(uint16_t cid, const ContigDeltaClassification& classification)
     {
+        assert(classification.kind == ContigDeltaKind::CARRY);
+        (void)classification;
         auto encoded = std::make_unique<CollectedData>(cid);
         auto& buf = encoded->getBuffer();
-        buf.append(contigActionFromKind_(classification.kind));
+        buf.append(Action::CARRY);
         return encoded;
     }
 
@@ -474,21 +441,6 @@ private:
         return checkpoint;
     }
 
-    /// Maps a sparse delta classification to its wire Action byte.
-    static Action sparseActionFromKind_(SparseDeltaKind kind)
-    {
-        switch (kind)
-        {
-        case SparseDeltaKind::CARRY:
-            return Action::CARRY;
-        case SparseDeltaKind::FULL:
-            break;
-        default:
-            break;
-        }
-        throw DBException("Invalid sparse delta kind");
-    }
-
     /// Appends the FULL tail for the current sparse snapshot to \p buf.
     void appendFullTail_(StreamBuffer& buf) const { appendSparseBins_(buf, full_bytes_); }
 
@@ -530,9 +482,11 @@ private:
     /// Encodes CARRY when the sparse snapshot is unchanged since the prior data checkpoint.
     std::unique_ptr<CollectedData> encodeDelta_(uint16_t cid, const SparseDeltaClassification& classification)
     {
+        assert(classification.kind == SparseDeltaKind::CARRY);
+        (void)classification;
         auto encoded = std::make_unique<CollectedData>(cid);
         auto& buf = encoded->getBuffer();
-        buf.append(sparseActionFromKind_(classification.kind));
+        buf.append(Action::CARRY);
         return encoded;
     }
 

--- a/include/simdb/apps/argos/CheckpointDeltas.hpp
+++ b/include/simdb/apps/argos/CheckpointDeltas.hpp
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "simdb/Exceptions.hpp"
-#include "simdb/utils/ValidValue.hpp"
 
 #include <cstdint>
 #include <iostream>
@@ -41,28 +40,12 @@ inline std::ostream& operator<<(std::ostream& os, ScalarDeltaKind kind)
 }
 
 //! Contiguous-container delta kinds.
-enum class ContigDeltaKind {
-    CARRY,
-    SWAP,
-    MULTI_SWAP,
-    BOOKENDS,
-    ARRIVE,
-    DEPART,
-    MIMO,
-    FULL,
-};
+enum class ContigDeltaKind { CARRY, FULL };
 
 //! Result of classifying a contig container transition.
 struct ContigDeltaClassification
 {
     ContigDeltaKind kind = ContigDeltaKind::FULL;
-    simdb::ValidValue<uint16_t> swap_index;
-    std::vector<char> payload;
-    uint8_t depart_count = 0;
-    uint8_t arrive_count = 0;
-    std::vector<std::vector<char>> arrive_payloads;
-    std::vector<uint16_t> swap_indices;
-    std::vector<std::vector<char>> swap_payloads;
 };
 
 inline uint16_t countContigElements(const std::vector<std::vector<char>>& contig_bins)
@@ -125,18 +108,6 @@ inline std::ostream& operator<<(std::ostream& os, ContigDeltaKind kind)
     {
     case ContigDeltaKind::CARRY:
         return os << "CARRY";
-    case ContigDeltaKind::SWAP:
-        return os << "SWAP";
-    case ContigDeltaKind::MULTI_SWAP:
-        return os << "MULTI_SWAP";
-    case ContigDeltaKind::BOOKENDS:
-        return os << "BOOKENDS";
-    case ContigDeltaKind::ARRIVE:
-        return os << "ARRIVE";
-    case ContigDeltaKind::DEPART:
-        return os << "DEPART";
-    case ContigDeltaKind::MIMO:
-        return os << "MIMO";
     case ContigDeltaKind::FULL:
         return os << "FULL";
     }
@@ -144,24 +115,12 @@ inline std::ostream& operator<<(std::ostream& os, ContigDeltaKind kind)
 }
 
 //! Sparse-container delta kinds.
-enum class SparseDeltaKind {
-    CARRY,
-    SWAP,
-    MULTI_SWAP,
-    REMOVE,
-    ADD,
-    MULTI_REMOVE,
-    FULL,
-};
+enum class SparseDeltaKind { CARRY, FULL };
 
 //! Result of classifying a sparse container transition.
 struct SparseDeltaClassification
 {
     SparseDeltaKind kind = SparseDeltaKind::FULL;
-    simdb::ValidValue<uint16_t> bin_index;
-    std::vector<char> payload;
-    std::vector<uint16_t> bin_indices;
-    std::vector<std::vector<char>> payloads;
 };
 
 inline uint16_t countSparseElements(const std::map<uint16_t, std::vector<char>>& sparse_bins)
@@ -209,16 +168,6 @@ inline std::ostream& operator<<(std::ostream& os, SparseDeltaKind kind)
     {
     case SparseDeltaKind::CARRY:
         return os << "CARRY";
-    case SparseDeltaKind::SWAP:
-        return os << "SWAP";
-    case SparseDeltaKind::MULTI_SWAP:
-        return os << "MULTI_SWAP";
-    case SparseDeltaKind::REMOVE:
-        return os << "REMOVE";
-    case SparseDeltaKind::ADD:
-        return os << "ADD";
-    case SparseDeltaKind::MULTI_REMOVE:
-        return os << "MULTI_REMOVE";
     case SparseDeltaKind::FULL:
         return os << "FULL";
     }

--- a/include/simdb/apps/argos/CheckpointDeltas.hpp
+++ b/include/simdb/apps/argos/CheckpointDeltas.hpp
@@ -1,0 +1,228 @@
+// <CheckpointDeltas.hpp> -*- C++ -*-
+
+#pragma once
+
+#include "simdb/Exceptions.hpp"
+#include "simdb/utils/ValidValue.hpp"
+
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <vector>
+
+namespace simdb::argos {
+
+//! Result of comparing two consecutive scalar payloads.
+enum class ScalarDeltaKind { UNCHANGED, CHANGED };
+
+//! Compare previous and current scalar payloads.
+//! Returns CHANGED when \p prev is empty (first collection has no baseline).
+//! Scalars only support CARRY when UNCHANGED; CHANGED implies a FULL snapshot.
+inline ScalarDeltaKind classifyScalarChange(const std::vector<char>& prev, const std::vector<char>& curr)
+{
+    if (prev.empty())
+    {
+        return ScalarDeltaKind::CHANGED;
+    }
+
+    return prev == curr ? ScalarDeltaKind::UNCHANGED : ScalarDeltaKind::CHANGED;
+}
+
+inline std::ostream& operator<<(std::ostream& os, ScalarDeltaKind kind)
+{
+    switch (kind)
+    {
+    case ScalarDeltaKind::UNCHANGED:
+        return os << "UNCHANGED";
+    case ScalarDeltaKind::CHANGED:
+        return os << "CHANGED";
+    }
+    throw DBException("Invalid ScalarDeltaKind");
+}
+
+//! Contiguous-container delta kinds.
+enum class ContigDeltaKind {
+    CARRY,
+    SWAP,
+    MULTI_SWAP,
+    BOOKENDS,
+    ARRIVE,
+    DEPART,
+    MIMO,
+    FULL,
+};
+
+//! Result of classifying a contig container transition.
+struct ContigDeltaClassification
+{
+    ContigDeltaKind kind = ContigDeltaKind::FULL;
+    simdb::ValidValue<uint16_t> swap_index;
+    std::vector<char> payload;
+    uint8_t depart_count = 0;
+    uint8_t arrive_count = 0;
+    std::vector<std::vector<char>> arrive_payloads;
+    std::vector<uint16_t> swap_indices;
+    std::vector<std::vector<char>> swap_payloads;
+};
+
+inline uint16_t countContigElements(const std::vector<std::vector<char>>& contig_bins)
+{
+    uint64_t count = 0;
+    for (const auto& bytes : contig_bins)
+    {
+        if (!bytes.empty())
+        {
+            ++count;
+        } else
+        {
+            break;
+        }
+    }
+    assert(count <= UINT16_MAX);
+    return count;
+}
+
+//! Classify how a contiguous container changed between consecutive collections.
+//!
+//! Returns FULL when \p prev is empty (no baseline). Heartbeat forcing is handled
+//! by the checkpointer, not this helper.
+inline ContigDeltaClassification classifyContigChange(const std::vector<std::vector<char>>& prev,
+                                                      const std::vector<std::vector<char>>& curr)
+{
+    ContigDeltaClassification result;
+
+    if (prev.empty())
+    {
+        result.kind = ContigDeltaKind::FULL;
+        return result;
+    }
+
+    const auto curr_size = countContigElements(curr);
+    const auto prev_size = countContigElements(prev);
+
+    if (curr_size == prev_size)
+    {
+        for (uint16_t i = 0; i < curr_size; ++i)
+        {
+            if (curr[i] != prev[i])
+            {
+                result.kind = ContigDeltaKind::FULL;
+                return result;
+            }
+        }
+
+        result.kind = ContigDeltaKind::CARRY;
+        return result;
+    }
+
+    result.kind = ContigDeltaKind::FULL;
+    return result;
+}
+
+inline std::ostream& operator<<(std::ostream& os, ContigDeltaKind kind)
+{
+    switch (kind)
+    {
+    case ContigDeltaKind::CARRY:
+        return os << "CARRY";
+    case ContigDeltaKind::SWAP:
+        return os << "SWAP";
+    case ContigDeltaKind::MULTI_SWAP:
+        return os << "MULTI_SWAP";
+    case ContigDeltaKind::BOOKENDS:
+        return os << "BOOKENDS";
+    case ContigDeltaKind::ARRIVE:
+        return os << "ARRIVE";
+    case ContigDeltaKind::DEPART:
+        return os << "DEPART";
+    case ContigDeltaKind::MIMO:
+        return os << "MIMO";
+    case ContigDeltaKind::FULL:
+        return os << "FULL";
+    }
+    throw DBException("Invalid ContigDeltaKind");
+}
+
+//! Sparse-container delta kinds.
+enum class SparseDeltaKind {
+    CARRY,
+    SWAP,
+    MULTI_SWAP,
+    REMOVE,
+    ADD,
+    MULTI_REMOVE,
+    FULL,
+};
+
+//! Result of classifying a sparse container transition.
+struct SparseDeltaClassification
+{
+    SparseDeltaKind kind = SparseDeltaKind::FULL;
+    simdb::ValidValue<uint16_t> bin_index;
+    std::vector<char> payload;
+    std::vector<uint16_t> bin_indices;
+    std::vector<std::vector<char>> payloads;
+};
+
+inline uint16_t countSparseElements(const std::map<uint16_t, std::vector<char>>& sparse_bins)
+{
+    uint64_t count = 0;
+    for (const auto& [_, bytes] : sparse_bins)
+    {
+        if (!bytes.empty())
+        {
+            ++count;
+        }
+    }
+    assert(count <= UINT16_MAX);
+    return static_cast<uint16_t>(count);
+}
+
+//! Classify how a sparse container changed between consecutive collections.
+//!
+//! Returns FULL when \p prev is empty (no baseline). Heartbeat forcing is handled
+//! by the checkpointer, not this helper.
+inline SparseDeltaClassification classifySparseChange(const std::map<uint16_t, std::vector<char>>& prev,
+                                                      const std::map<uint16_t, std::vector<char>>& curr)
+{
+    SparseDeltaClassification result;
+
+    if (prev.empty())
+    {
+        result.kind = SparseDeltaKind::FULL;
+        return result;
+    }
+
+    if (curr == prev)
+    {
+        result.kind = SparseDeltaKind::CARRY;
+        return result;
+    }
+
+    result.kind = SparseDeltaKind::FULL;
+    return result;
+}
+
+inline std::ostream& operator<<(std::ostream& os, SparseDeltaKind kind)
+{
+    switch (kind)
+    {
+    case SparseDeltaKind::CARRY:
+        return os << "CARRY";
+    case SparseDeltaKind::SWAP:
+        return os << "SWAP";
+    case SparseDeltaKind::MULTI_SWAP:
+        return os << "MULTI_SWAP";
+    case SparseDeltaKind::REMOVE:
+        return os << "REMOVE";
+    case SparseDeltaKind::ADD:
+        return os << "ADD";
+    case SparseDeltaKind::MULTI_REMOVE:
+        return os << "MULTI_REMOVE";
+    case SparseDeltaKind::FULL:
+        return os << "FULL";
+    }
+    throw DBException("Invalid SparseDeltaKind");
+}
+
+} // namespace simdb::argos

--- a/include/simdb/apps/argos/CheckpointEncodings.hpp
+++ b/include/simdb/apps/argos/CheckpointEncodings.hpp
@@ -1,0 +1,84 @@
+// <CheckpointEncodings.hpp> -*- C++ -*-
+
+// clang-format off
+
+#pragma once
+
+/*!
+ * \file CheckpointEncodings.hpp
+ * \brief Reference for wire delta encodings emitted by PipelineStager checkpointers.
+ *
+ * The PipelineStager stage in ArgosCollector calls each collectable's checkpointer
+ * (`ScalarCheckpointer`, `ContigContainerCheckpointer`, `SparseContainerCheckpointer`)
+ * to turn staged checkpoints into wire records. Each record is prefixed with:
+ *
+ *   [uint16_t cid]     collectable ID
+ *   [uint8_t action]   encoding (see Action in Checkpoint.hpp)
+ *
+ * Delta classification lives in CheckpointDeltas.hpp (`classifyContigChange`,
+ * `classifySparseChange`). Heartbeat forcing, absent-CID refresh, and CLOSED priming
+ * are handled in Checkpointer.hpp (`CollectableCheckpointer`).
+ *
+ * \par Encoding reference (tier 1)
+ *
+ * \verbatim
+ * Encoding                 Applies To       Used When
+ * ------------------------ ---------------- ------------------------------------------------------------------------------
+ * CLOSED                   All              Collectable transitions to closed (`closeRecord`). The checkpointer may emit a
+ *                                           priming FULL first when the last snapshot is outside the current heartbeat
+ *                                           window.
+ * FULL                     All              First data checkpoint (no prior baseline); heartbeat forces a snapshot; delta
+ *                                           chain reaches `heartbeat - 1` consecutive non-FULL records; a CLOSED event
+ *                                           occurred since the prior data checkpoint; scalar bytes changed; container
+ *                                           change pattern is not covered by any delta; collectable did not stage this
+ *                                           window but heartbeat refresh requires re-emitting state
+ *                                           (`shouldRefreshAbsentCid_`).
+ * CARRY                    All              Payload unchanged since the prior data checkpoint and none of the FULL forcing
+ *                                           rules apply.
+ * \endverbatim
+ *
+ * Scalars only ever emit CLOSED, FULL, or CARRY. Container delta encodings (tiers 2–4)
+ * are reserved in the Action enum and documented in follow-on PRs.
+ *
+ * \par FULL forcing (checkpointer layer)
+ *
+ * These conditions override delta classification and force FULL regardless of change size:
+ *
+ * - \c forceSnapshot_(sim_time) — either `distance_to_snapshot_ + 1 >= heartbeat_`, or the
+ *   last FULL sim-time is outside the current heartbeat window (`shouldHeartbeatRefresh_`).
+ * - No prior data checkpoint — first collection for this CID.
+ * - Closed since prior data checkpoint — a CLOSED lifecycle node sits between the current
+ *   data checkpoint and the previous one.
+ * - Absent CID refresh — collectable did not participate in this window but heartbeat
+ *   policy still requires a wire record (replays latest snapshot as FULL, or CLOSED plus
+ *   optional priming FULL if already closed).
+ *
+ * \par Wire payloads (after the action byte)
+ *
+ * | Action                 | Payload                                                |
+ * |------------------------|--------------------------------------------------------|
+ * | CLOSED                 |                                                        |
+ * | CARRY                  |                                                        |
+ * | FULL (scalar)          | [scalar bytes]                                         |
+ * | FULL (contig)          | [count][bin bytes]..[bin bytes]                        |
+ * | FULL (sparse)          | [count][bin idx][bin bytes]..[bin idx][bin bytes]      |
+ *
+ * \par Action enum tiers (Checkpoint.hpp)
+ *
+ * - Tier 1 (`0x00`–`0x0F`): lifecycle / common — CLOSED, FULL, CARRY; `0x03`–`0x0F` reserved
+ * - Tier 2 (`0x10`–`0x1F`): any-container — CONTAINER_SWAP, CONTAINER_MULTI_SWAP;
+ *   `0x12`–`0x1F` reserved
+ * - Tier 3 (`0x20`–`0x2F`): contig-specific — CONTIG_ARRIVE, CONTIG_DEPART, CONTIG_BOOKENDS,
+ *   CONTIG_MIMO; `0x24`–`0x2F` reserved
+ * - Tier 4 (`0x30`–`0x3F`): sparse-specific — SPARSE_REMOVE, SPARSE_ADD, SPARSE_MULTI_REMOVE;
+ *   `0x33`–`0x3F` reserved
+ *
+ * \par Related implementation files
+ *
+ * - Checkpoint.hpp:       Action enum, encode/decode per checkpoint type
+ * - CheckpointDeltas.hpp: classifyContigChange, classifySparseChange
+ * - Checkpointer.hpp:     heartbeat bookkeeping, encodeForPipeline orchestration
+ * - ArgosCollector.hpp:   PipelineStager invokes checkpointer encoding
+ */
+
+// clang-format on

--- a/include/simdb/apps/argos/CheckpointEncodings.hpp
+++ b/include/simdb/apps/argos/CheckpointEncodings.hpp
@@ -37,8 +37,7 @@
  *                                           rules apply.
  * \endverbatim
  *
- * Scalars only ever emit CLOSED, FULL, or CARRY. Container delta encodings (tiers 2–4)
- * are reserved in the Action enum and documented in follow-on PRs.
+ * Scalars only ever emit CLOSED, FULL, or CARRY.
  *
  * \par FULL forcing (checkpointer layer)
  *
@@ -62,16 +61,6 @@
  * | FULL (scalar)          | [scalar bytes]                                         |
  * | FULL (contig)          | [count][bin bytes]..[bin bytes]                        |
  * | FULL (sparse)          | [count][bin idx][bin bytes]..[bin idx][bin bytes]      |
- *
- * \par Action enum tiers (Checkpoint.hpp)
- *
- * - Tier 1 (`0x00`–`0x0F`): lifecycle / common — CLOSED, FULL, CARRY; `0x03`–`0x0F` reserved
- * - Tier 2 (`0x10`–`0x1F`): any-container — CONTAINER_SWAP, CONTAINER_MULTI_SWAP;
- *   `0x12`–`0x1F` reserved
- * - Tier 3 (`0x20`–`0x2F`): contig-specific — CONTIG_ARRIVE, CONTIG_DEPART, CONTIG_BOOKENDS,
- *   CONTIG_MIMO; `0x24`–`0x2F` reserved
- * - Tier 4 (`0x30`–`0x3F`): sparse-specific — SPARSE_REMOVE, SPARSE_ADD, SPARSE_MULTI_REMOVE;
- *   `0x33`–`0x3F` reserved
  *
  * \par Related implementation files
  *

--- a/include/simdb/apps/argos/Checkpointer.hpp
+++ b/include/simdb/apps/argos/Checkpointer.hpp
@@ -1,0 +1,692 @@
+// <Checkpointer.hpp> -*- C++ -*-
+
+#pragma once
+
+#include "simdb/apps/argos/Checkpoint.hpp"
+#include "simdb/sqlite/DatabaseManager.hpp"
+#include "simdb/utils/ValidValue.hpp"
+
+#include <vector>
+
+namespace simdb::argos {
+
+namespace detail {
+/// Counts occupied front-packed bins in a contig snapshot.
+inline uint16_t getContainerSize(const std::vector<std::vector<char>>& contig_bin_bytes)
+{
+    uint64_t size = 0;
+    for (const auto& bin_bytes : contig_bin_bytes)
+    {
+        if (!bin_bytes.empty())
+        {
+            ++size;
+        } else
+        {
+            break;
+        }
+    }
+    assert(size <= UINT16_MAX);
+    return size;
+}
+
+/// Counts occupied bins in a sparse snapshot.
+inline uint16_t getContainerSize(const std::map<uint16_t, std::vector<char>>& sparse_bin_bytes)
+{
+    uint64_t size = 0;
+    for (const auto& [_, bin_bytes] : sparse_bin_bytes)
+    {
+        if (!bin_bytes.empty())
+        {
+            ++size;
+        }
+    }
+    assert(size <= UINT16_MAX);
+    return size;
+}
+} // namespace detail
+
+//! \class CollectableCheckpointer
+class CollectableCheckpointer
+{
+public:
+    /// Destroys the checkpointer and its checkpoint chain.
+    virtual ~CollectableCheckpointer() = default;
+
+    /// Appends a scalar snapshot checkpoint; \throws DBException on unsupported checkpointer types.
+    virtual void createCheckpoint(uint64_t window_id, const std::vector<char>& scalar_bytes)
+    {
+        (void)window_id;
+        (void)scalar_bytes;
+        throw DBException("Not implemented");
+    }
+
+    /// Appends a contig container snapshot checkpoint; \throws DBException on unsupported checkpointer types.
+    virtual void createCheckpoint(uint64_t window_id, const std::vector<std::vector<char>>& contig_bin_bytes)
+    {
+        (void)window_id;
+        (void)contig_bin_bytes;
+        throw DBException("Not implemented");
+    }
+
+    /// Appends a sparse container snapshot checkpoint; \throws DBException on unsupported checkpointer types.
+    virtual void createCheckpoint(uint64_t window_id, const std::map<uint16_t, std::vector<char>>& sparse_bin_bytes)
+    {
+        (void)window_id;
+        (void)sparse_bin_bytes;
+        throw DBException("Not implemented");
+    }
+
+    /// Records a closed lifecycle event at \p window_id.
+    virtual void closeRecord(uint64_t window_id) = 0;
+
+    /// Encodes wire records for \p cid at \p sim_time, using the checkpoint for \p window_id when present.
+    virtual std::vector<std::unique_ptr<CollectedData>> encodeForPipeline(uint64_t window_id, uint64_t sim_time,
+                                                                          uint16_t cid) = 0;
+
+    /// Returns true if this collectable staged data in \p window_id.
+    virtual bool participatedInWindow(uint64_t window_id) const = 0;
+
+    /// Writes collectable-specific metadata after simulation teardown; default is a no-op.
+    virtual void writeMetaOnPostTeardown(uint16_t cid, DatabaseManager*) { (void)cid; }
+
+protected:
+    /// Stores the heartbeat interval used to force periodic FULL snapshots.
+    explicit CollectableCheckpointer(size_t heartbeat) :
+        heartbeat_(heartbeat)
+    {
+    }
+
+    /// Finds the latest checkpoint in \p tail at or before \p window_id.
+    template <typename CheckpointT>
+    static CheckpointT* getAnchorForWindow_(uint64_t window_id, const std::shared_ptr<CheckpointT>& tail)
+    {
+        CheckpointT* anchor = tail.get();
+        CheckpointT* best = nullptr;
+        while (anchor)
+        {
+            if (anchor->getWindowID() > window_id)
+            {
+                break;
+            }
+            best = anchor;
+            anchor = anchor->next();
+        }
+        return best;
+    }
+
+    /// Returns true if \p tail contains a checkpoint whose window equals \p window_id.
+    template <typename CheckpointT>
+    static bool participatedInWindow_(uint64_t window_id, const std::shared_ptr<CheckpointT>& tail)
+    {
+        if (!tail)
+        {
+            return false;
+        }
+        auto* anchor = getAnchorForWindow_(window_id, tail);
+        return anchor && anchor->getWindowID() == window_id;
+    }
+
+    /// Locates the shared_ptr in \p head that owns \p raw.
+    template <typename CheckpointT>
+    static std::shared_ptr<CheckpointT> getSharedCheckpoint_(CheckpointT* raw, const std::shared_ptr<CheckpointT>& head)
+    {
+        std::shared_ptr<CheckpointT> sp = head;
+        while (sp)
+        {
+            if (sp.get() == raw)
+            {
+                return sp;
+            }
+            auto prev = sp->getPrevShared();
+            if (!prev)
+            {
+                return nullptr;
+            }
+            sp = std::static_pointer_cast<CheckpointT>(prev);
+        }
+        return nullptr;
+    }
+
+    /// Reads the action byte from an encoded wire record (after the CID prefix).
+    static Action readEncodedAction_(const CollectedData& encoded)
+    {
+        return static_cast<Action>(encoded.getData().at(sizeof(uint16_t)));
+    }
+
+    /// Wraps a single encoded record in a one-element vector.
+    template <typename T> static std::vector<T> makeSingleElemVector_(T&& only)
+    {
+        std::vector<T> out;
+        out.emplace_back(std::move(only));
+        return out;
+    }
+
+    /// Returns true when the next wire must be a FULL snapshot (delta limit or heartbeat window).
+    bool forceSnapshot_(uint64_t sim_time) const
+    {
+        return distance_to_snapshot_ + 1 >= heartbeat_ || shouldHeartbeatRefresh_(sim_time);
+    }
+
+    /// Returns true when the last FULL wire is outside the current heartbeat window.
+    bool shouldHeartbeatRefresh_(uint64_t sim_time) const
+    {
+        if (!last_snapshot_sim_time_.isValid())
+        {
+            return false;
+        }
+        if (sim_time <= last_snapshot_sim_time_.getValue())
+        {
+            return false;
+        }
+        const uint64_t window_lo = sim_time >= heartbeat_ ? sim_time - heartbeat_ + 1 : 0;
+        return last_snapshot_sim_time_.getValue() < window_lo;
+    }
+
+    /// Returns true when a CID that skipped this window still needs a heartbeat refresh on the wire.
+    bool shouldRefreshAbsentCid_(uint64_t sim_time, bool tip_closed) const
+    {
+        if (shouldHeartbeatRefresh_(sim_time))
+        {
+            return true;
+        }
+        if (!tip_closed || !last_record_closed_sim_time_.isValid() ||
+            sim_time <= last_record_closed_sim_time_.getValue())
+        {
+            return false;
+        }
+        const uint64_t window_lo = sim_time >= heartbeat_ ? sim_time - heartbeat_ + 1 : 0;
+        return last_record_closed_sim_time_.getValue() < window_lo;
+    }
+
+    /// Returns true when a CLOSED wire should be preceded by a priming FULL snapshot.
+    bool needsClosedPriming_(uint64_t sim_time) const
+    {
+        if (!last_snapshot_sim_time_.isValid())
+        {
+            return true;
+        }
+        const uint64_t window_lo = sim_time >= heartbeat_ ? sim_time - heartbeat_ + 1 : 0;
+        return last_snapshot_sim_time_.getValue() < window_lo;
+    }
+
+    /// Updates delta-chain and heartbeat bookkeeping after a wire is emitted.
+    void recordCidSent_(Action action, uint64_t sim_time)
+    {
+        if (action == Action::FULL)
+        {
+            distance_to_snapshot_ = 0;
+        } else
+        {
+            ++distance_to_snapshot_;
+        }
+
+        if (action == Action::FULL)
+        {
+            last_snapshot_sim_time_ = sim_time;
+        } else if (action == Action::CLOSED)
+        {
+            last_record_closed_sim_time_ = sim_time;
+        }
+    }
+
+    const size_t heartbeat_;
+    size_t distance_to_snapshot_ = 0;
+    ValidValue<uint64_t> last_snapshot_sim_time_;
+    ValidValue<uint64_t> last_record_closed_sim_time_;
+};
+
+//! \class ScalarCheckpointer
+class ScalarCheckpointer final : public CollectableCheckpointer
+{
+public:
+    /// Constructs a scalar checkpointer with the given heartbeat interval.
+    ScalarCheckpointer(size_t heartbeat) :
+        CollectableCheckpointer(heartbeat)
+    {
+    }
+
+    /// Appends a scalar data checkpoint for \p window_id.
+    void createCheckpoint(uint64_t window_id, const std::vector<char>& scalar_bytes) override
+    {
+        head_ = std::make_shared<ScalarCheckpoint>(head_, window_id, scalar_bytes);
+        if (!tail_)
+        {
+            tail_ = head_;
+        }
+    }
+
+    using CollectableCheckpointer::createCheckpoint; // un-hide the other two
+
+    /// Appends a scalar close lifecycle checkpoint for \p window_id.
+    void closeRecord(uint64_t window_id) override
+    {
+        constexpr bool closed = true;
+        head_ = std::make_shared<ScalarCheckpoint>(head_, window_id, closed);
+        if (!tail_)
+        {
+            tail_ = head_;
+        }
+    }
+
+    /// Returns true if this scalar collectable staged data in \p window_id.
+    bool participatedInWindow(uint64_t window_id) const override { return participatedInWindow_(window_id, tail_); }
+
+    /// Encodes scalar wire records for \p cid at \p sim_time.
+    std::vector<std::unique_ptr<CollectedData>> encodeForPipeline(uint64_t window_id, uint64_t sim_time,
+                                                                  uint16_t cid) override
+    {
+        auto* anchor = getAnchorForWindow_(window_id, tail_);
+        if (anchor && anchor->getWindowID() == window_id)
+        {
+            return encodeForPipeline_(anchor, cid, forceSnapshot_(sim_time), sim_time);
+        }
+
+        auto* tip = head_.get();
+        const bool tip_closed = tip && tip->isClosedEvent();
+        if (shouldRefreshAbsentCid_(sim_time, tip_closed))
+        {
+            if (tip_closed)
+            {
+                return emitRecordClosed_(cid, sim_time);
+            }
+
+            auto* latest = latestDataCheckpoint_();
+            if (!latest)
+            {
+                return {};
+            }
+
+            auto encoded = latest->encodeSnapshotForPipeline(cid);
+            recordCidSent_(Action::FULL, sim_time);
+            return makeSingleElemVector_(std::move(encoded));
+        }
+
+        return {};
+    }
+
+private:
+    /// Returns the newest scalar data checkpoint, skipping lifecycle-only nodes.
+    ScalarCheckpoint* latestDataCheckpoint_() const
+    {
+        auto* checkpoint = head_.get();
+        while (checkpoint && !checkpoint->isDataCheckpoint())
+        {
+            checkpoint = checkpoint->prev();
+        }
+        return checkpoint;
+    }
+
+    /// Emits CLOSED, optionally priming with FULL when the heartbeat window requires it.
+    std::vector<std::unique_ptr<CollectedData>> emitRecordClosed_(uint16_t cid, uint64_t sim_time)
+    {
+        std::vector<std::unique_ptr<CollectedData>> out;
+        if (needsClosedPriming_(sim_time))
+        {
+            if (auto* latest = latestDataCheckpoint_())
+            {
+                out.push_back(latest->encodeSnapshotForPipeline(cid));
+                recordCidSent_(Action::FULL, sim_time);
+            }
+        }
+
+        auto encoded = std::make_unique<CollectedData>(cid);
+        encoded->getBuffer().append(Action::CLOSED);
+        recordCidSent_(Action::CLOSED, sim_time);
+        out.push_back(std::move(encoded));
+        return out;
+    }
+
+    /// Encodes the scalar checkpoint at \p anchor and trims the chain through that node.
+    std::vector<std::unique_ptr<CollectedData>> encodeForPipeline_(ScalarCheckpoint* anchor, uint16_t cid,
+                                                                   bool force_snapshot, uint64_t sim_time)
+    {
+        auto encoded = anchor->encodeForPipeline(cid, force_snapshot);
+        if (!encoded)
+        {
+            return {};
+        }
+
+        const auto action = readEncodedAction_(*encoded);
+        if (action == Action::CLOSED)
+        {
+            cleanupThrough_(anchor, action);
+            return emitRecordClosed_(cid, sim_time);
+        }
+
+        recordCidSent_(action, sim_time);
+        cleanupThrough_(anchor, action);
+        return makeSingleElemVector_(std::move(encoded));
+    }
+
+    /// Advances \p tail_ to \p anchor and detaches earlier nodes on FULL.
+    void cleanupThrough_(ScalarCheckpoint* anchor, Action action)
+    {
+        auto sp = getSharedCheckpoint_(anchor, head_);
+        if (!sp)
+        {
+            return;
+        }
+        if (action == Action::FULL)
+        {
+            sp->detachPrev();
+        }
+        tail_ = sp;
+    }
+
+    std::shared_ptr<ScalarCheckpoint> head_;
+    std::shared_ptr<ScalarCheckpoint> tail_;
+};
+
+//! \class ContigContainerCheckpointer
+class ContigContainerCheckpointer final : public CollectableCheckpointer
+{
+public:
+    /// Constructs a contig checkpointer with heartbeat and fixed capacity.
+    ContigContainerCheckpointer(size_t heartbeat, size_t capacity) :
+        CollectableCheckpointer(heartbeat),
+        capacity_(capacity)
+    {
+    }
+
+    /// Appends a contig container data checkpoint for \p window_id.
+    void createCheckpoint(uint64_t window_id, const std::vector<std::vector<char>>& contig_bin_bytes) override
+    {
+        auto size = detail::getContainerSize(contig_bin_bytes);
+        assert(size <= capacity_);
+        (void)capacity_;
+        max_container_size_ = std::max(max_container_size_, size);
+
+        head_ = std::make_shared<ContigContainerCheckpoint>(head_, window_id, contig_bin_bytes);
+        if (!tail_)
+        {
+            tail_ = head_;
+        }
+    }
+
+    using CollectableCheckpointer::createCheckpoint; // un-hide the other two
+
+    /// Appends a contig close lifecycle checkpoint for \p window_id.
+    void closeRecord(uint64_t window_id) override
+    {
+        constexpr bool closed = true;
+        head_ = std::make_shared<ContigContainerCheckpoint>(head_, window_id, closed);
+        if (!tail_)
+        {
+            tail_ = head_;
+        }
+    }
+
+    /// Returns true if this contig collectable staged data in \p window_id.
+    bool participatedInWindow(uint64_t window_id) const override { return participatedInWindow_(window_id, tail_); }
+
+    /// Encodes contig container wire records for \p cid at \p sim_time.
+    std::vector<std::unique_ptr<CollectedData>> encodeForPipeline(uint64_t window_id, uint64_t sim_time,
+                                                                  uint16_t cid) override
+    {
+        auto* anchor = getAnchorForWindow_(window_id, tail_);
+        if (anchor && anchor->getWindowID() == window_id)
+        {
+            return encodeForPipeline_(anchor, cid, forceSnapshot_(sim_time), sim_time);
+        }
+
+        auto* tip = head_.get();
+        const bool tip_closed = tip && tip->isClosedEvent();
+        if (shouldRefreshAbsentCid_(sim_time, tip_closed))
+        {
+            if (tip_closed)
+            {
+                return emitRecordClosed_(cid, sim_time);
+            }
+
+            auto* latest = latestDataCheckpoint_();
+            if (!latest)
+            {
+                return {};
+            }
+
+            auto encoded = latest->encodeSnapshotForPipeline(cid);
+            recordCidSent_(Action::FULL, sim_time);
+            return makeSingleElemVector_(std::move(encoded));
+        }
+
+        return {};
+    }
+
+    /// Writes observed max queue occupancy to QueueMaxSizes.
+    void writeMetaOnPostTeardown(uint16_t cid, DatabaseManager* db_mgr) override
+    {
+        db_mgr->INSERT(SQL_TABLE("QueueMaxSizes"), SQL_VALUES((int)cid, (int)max_container_size_));
+    }
+
+private:
+    /// Returns the newest contig data checkpoint, skipping lifecycle-only nodes.
+    ContigContainerCheckpoint* latestDataCheckpoint_() const
+    {
+        auto* checkpoint = head_.get();
+        while (checkpoint && !checkpoint->isDataCheckpoint())
+        {
+            checkpoint = checkpoint->prev();
+        }
+        return checkpoint;
+    }
+
+    /// Emits CLOSED, optionally priming with FULL when the heartbeat window requires it.
+    std::vector<std::unique_ptr<CollectedData>> emitRecordClosed_(uint16_t cid, uint64_t sim_time)
+    {
+        std::vector<std::unique_ptr<CollectedData>> out;
+        if (needsClosedPriming_(sim_time))
+        {
+            if (auto* latest = latestDataCheckpoint_())
+            {
+                out.push_back(latest->encodeSnapshotForPipeline(cid));
+                recordCidSent_(Action::FULL, sim_time);
+            }
+        }
+
+        auto encoded = std::make_unique<CollectedData>(cid);
+        encoded->getBuffer().append(Action::CLOSED);
+        recordCidSent_(Action::CLOSED, sim_time);
+        out.push_back(std::move(encoded));
+        return out;
+    }
+
+    /// Encodes the contig checkpoint at \p anchor and trims the chain through that node.
+    std::vector<std::unique_ptr<CollectedData>> encodeForPipeline_(ContigContainerCheckpoint* anchor, uint16_t cid,
+                                                                   bool force_snapshot, uint64_t sim_time)
+    {
+        auto encoded = anchor->encodeForPipeline(cid, force_snapshot);
+        if (!encoded)
+        {
+            return {};
+        }
+
+        const auto action = readEncodedAction_(*encoded);
+        if (action == Action::CLOSED)
+        {
+            cleanupThrough_(anchor, action);
+            return emitRecordClosed_(cid, sim_time);
+        }
+
+        recordCidSent_(action, sim_time);
+        cleanupThrough_(anchor, action);
+        return makeSingleElemVector_(std::move(encoded));
+    }
+
+    /// Advances \p tail_ to \p anchor and detaches earlier nodes on FULL.
+    void cleanupThrough_(ContigContainerCheckpoint* anchor, Action action)
+    {
+        auto sp = getSharedCheckpoint_(anchor, head_);
+        if (!sp)
+        {
+            return;
+        }
+        if (action == Action::FULL)
+        {
+            sp->detachPrev();
+        }
+        tail_ = sp;
+    }
+
+    std::shared_ptr<ContigContainerCheckpoint> head_;
+    std::shared_ptr<ContigContainerCheckpoint> tail_;
+    uint16_t max_container_size_ = 0;
+    const uint16_t capacity_;
+};
+
+//! \class SparseContainerCheckpointer
+class SparseContainerCheckpointer final : public CollectableCheckpointer
+{
+public:
+    /// Constructs a sparse checkpointer with heartbeat and fixed capacity.
+    SparseContainerCheckpointer(size_t heartbeat, size_t capacity) :
+        CollectableCheckpointer(heartbeat),
+        capacity_(capacity)
+    {
+    }
+
+    /// Appends a sparse container data checkpoint for \p window_id.
+    void createCheckpoint(uint64_t window_id, const std::map<uint16_t, std::vector<char>>& sparse_bin_bytes) override
+    {
+        auto size = detail::getContainerSize(sparse_bin_bytes);
+        assert(size <= capacity_);
+        (void)capacity_;
+        max_container_size_ = std::max(max_container_size_, size);
+
+        head_ = std::make_shared<SparseContainerCheckpoint>(head_, window_id, sparse_bin_bytes);
+        if (!tail_)
+        {
+            tail_ = head_;
+        }
+    }
+
+    using CollectableCheckpointer::createCheckpoint; // un-hide the other two
+
+    /// Appends a sparse close lifecycle checkpoint for \p window_id.
+    void closeRecord(uint64_t window_id) override
+    {
+        constexpr bool closed = true;
+        head_ = std::make_shared<SparseContainerCheckpoint>(head_, window_id, closed);
+        if (!tail_)
+        {
+            tail_ = head_;
+        }
+    }
+
+    /// Returns true if this sparse collectable staged data in \p window_id.
+    bool participatedInWindow(uint64_t window_id) const override { return participatedInWindow_(window_id, tail_); }
+
+    /// Encodes sparse container wire records for \p cid at \p sim_time.
+    std::vector<std::unique_ptr<CollectedData>> encodeForPipeline(uint64_t window_id, uint64_t sim_time,
+                                                                  uint16_t cid) override
+    {
+        auto* anchor = getAnchorForWindow_(window_id, tail_);
+        if (anchor && anchor->getWindowID() == window_id)
+        {
+            return encodeForPipeline_(anchor, cid, forceSnapshot_(sim_time), sim_time);
+        }
+
+        auto* tip = head_.get();
+        const bool tip_closed = tip && tip->isClosedEvent();
+        if (shouldRefreshAbsentCid_(sim_time, tip_closed))
+        {
+            if (tip_closed)
+            {
+                return emitRecordClosed_(cid, sim_time);
+            }
+
+            auto* latest = latestDataCheckpoint_();
+            if (!latest)
+            {
+                return {};
+            }
+
+            auto encoded = latest->encodeSnapshotForPipeline(cid);
+            recordCidSent_(Action::FULL, sim_time);
+            return makeSingleElemVector_(std::move(encoded));
+        }
+
+        return {};
+    }
+
+    /// Writes observed max queue occupancy to QueueMaxSizes.
+    void writeMetaOnPostTeardown(uint16_t cid, DatabaseManager* db_mgr) override
+    {
+        db_mgr->INSERT(SQL_TABLE("QueueMaxSizes"), SQL_VALUES((int)cid, (int)max_container_size_));
+    }
+
+private:
+    /// Returns the newest sparse data checkpoint, skipping lifecycle-only nodes.
+    SparseContainerCheckpoint* latestDataCheckpoint_() const
+    {
+        auto* checkpoint = head_.get();
+        while (checkpoint && !checkpoint->isDataCheckpoint())
+        {
+            checkpoint = checkpoint->prev();
+        }
+        return checkpoint;
+    }
+
+    /// Emits CLOSED, optionally priming with FULL when the heartbeat window requires it.
+    std::vector<std::unique_ptr<CollectedData>> emitRecordClosed_(uint16_t cid, uint64_t sim_time)
+    {
+        std::vector<std::unique_ptr<CollectedData>> out;
+        if (needsClosedPriming_(sim_time))
+        {
+            if (auto* latest = latestDataCheckpoint_())
+            {
+                out.push_back(latest->encodeSnapshotForPipeline(cid));
+                recordCidSent_(Action::FULL, sim_time);
+            }
+        }
+
+        auto encoded = std::make_unique<CollectedData>(cid);
+        encoded->getBuffer().append(Action::CLOSED);
+        recordCidSent_(Action::CLOSED, sim_time);
+        out.push_back(std::move(encoded));
+        return out;
+    }
+
+    /// Encodes the sparse checkpoint at \p anchor and trims the chain through that node.
+    std::vector<std::unique_ptr<CollectedData>> encodeForPipeline_(SparseContainerCheckpoint* anchor, uint16_t cid,
+                                                                   bool force_snapshot, uint64_t sim_time)
+    {
+        auto encoded = anchor->encodeForPipeline(cid, force_snapshot);
+        if (!encoded)
+        {
+            return {};
+        }
+
+        const auto action = readEncodedAction_(*encoded);
+        if (action == Action::CLOSED)
+        {
+            cleanupThrough_(anchor, action);
+            return emitRecordClosed_(cid, sim_time);
+        }
+
+        recordCidSent_(action, sim_time);
+        cleanupThrough_(anchor, action);
+        return makeSingleElemVector_(std::move(encoded));
+    }
+
+    /// Advances \p tail_ to \p anchor and detaches earlier nodes on FULL.
+    void cleanupThrough_(SparseContainerCheckpoint* anchor, Action action)
+    {
+        auto sp = getSharedCheckpoint_(anchor, head_);
+        if (!sp)
+        {
+            return;
+        }
+        if (action == Action::FULL)
+        {
+            sp->detachPrev();
+        }
+        tail_ = sp;
+    }
+
+    std::shared_ptr<SparseContainerCheckpoint> head_;
+    std::shared_ptr<SparseContainerCheckpoint> tail_;
+    uint16_t max_container_size_ = 0;
+    const uint16_t capacity_;
+};
+
+} // namespace simdb::argos


### PR DESCRIPTION
Wire PipelineStager to ScalarCheckpointer, ContigContainerCheckpointer, and SparseContainerCheckpointer so collection ledgers produce pipeline records. Container and sparse deltas beyond CARRY fall back to FULL until follow-on PRs add compact encodings.