### PR TITLE
Add container delta encodings (CONTAINER_SWAP, CONTAINER_MULTI_SWAP)

### DIFF
--- a/include/simdb/apps/argos/Checkpoint.hpp
+++ b/include/simdb/apps/argos/Checkpoint.hpp
@@ -20,6 +20,9 @@ enum class Action : uint8_t {
     CLOSED = 0x00,
     FULL = 0x01,
     CARRY = 0x02,
+
+    CONTAINER_SWAP = 0x10,
+    CONTAINER_MULTI_SWAP = 0x11,
 };
 
 //! \class CollectableCheckpoint
@@ -299,6 +302,23 @@ private:
         return checkpoint;
     }
 
+    /// Maps a contig delta classification to its wire Action byte.
+    static Action contigActionFromKind_(ContigDeltaKind kind)
+    {
+        switch (kind)
+        {
+        case ContigDeltaKind::CARRY:
+            return Action::CARRY;
+        case ContigDeltaKind::SWAP:
+            return Action::CONTAINER_SWAP;
+        case ContigDeltaKind::MULTI_SWAP:
+            return Action::CONTAINER_MULTI_SWAP;
+        case ContigDeltaKind::FULL:
+            break;
+        }
+        throw DBException("Invalid contig delta kind");
+    }
+
     /// Appends the FULL tail for the current contig snapshot to \p buf.
     void appendFullTail_(StreamBuffer& buf) const { appendContigBins_(buf, full_bytes_); }
 
@@ -333,14 +353,38 @@ private:
         return encoded;
     }
 
-    /// Encodes CARRY when the contig snapshot is unchanged since the prior data checkpoint.
+    /// Encodes a classified contig delta to the wire buffer.
     std::unique_ptr<CollectedData> encodeDelta_(uint16_t cid, const ContigDeltaClassification& classification)
     {
-        assert(classification.kind == ContigDeltaKind::CARRY);
-        (void)classification;
         auto encoded = std::make_unique<CollectedData>(cid);
         auto& buf = encoded->getBuffer();
-        buf.append(Action::CARRY);
+        const auto action = contigActionFromKind_(classification.kind);
+        buf.append(action);
+
+        switch (action)
+        {
+        case Action::CONTAINER_SWAP:
+            assert(classification.swap_index.isValid());
+            assert(!classification.payload.empty());
+            buf.append(classification.swap_index.getValue());
+            buf.append(classification.payload);
+            break;
+        case Action::CONTAINER_MULTI_SWAP:
+            assert(classification.swap_indices.size() >= 2);
+            assert(classification.swap_indices.size() == classification.swap_payloads.size());
+            buf.append(static_cast<uint8_t>(classification.swap_indices.size()));
+            for (size_t i = 0; i < classification.swap_indices.size(); ++i)
+            {
+                buf.append(classification.swap_indices[i]);
+                buf.append(classification.swap_payloads[i]);
+            }
+            break;
+        case Action::CARRY:
+            break;
+        default:
+            throw DBException("Unexpected contig delta action");
+        }
+
         return encoded;
     }
 
@@ -441,6 +485,23 @@ private:
         return checkpoint;
     }
 
+    /// Maps a sparse delta classification to its wire Action byte.
+    static Action sparseActionFromKind_(SparseDeltaKind kind)
+    {
+        switch (kind)
+        {
+        case SparseDeltaKind::CARRY:
+            return Action::CARRY;
+        case SparseDeltaKind::SWAP:
+            return Action::CONTAINER_SWAP;
+        case SparseDeltaKind::MULTI_SWAP:
+            return Action::CONTAINER_MULTI_SWAP;
+        case SparseDeltaKind::FULL:
+            break;
+        }
+        throw DBException("Invalid sparse delta kind");
+    }
+
     /// Appends the FULL tail for the current sparse snapshot to \p buf.
     void appendFullTail_(StreamBuffer& buf) const { appendSparseBins_(buf, full_bytes_); }
 
@@ -479,14 +540,38 @@ private:
         return encoded;
     }
 
-    /// Encodes CARRY when the sparse snapshot is unchanged since the prior data checkpoint.
+    /// Encodes a classified sparse delta to the wire buffer.
     std::unique_ptr<CollectedData> encodeDelta_(uint16_t cid, const SparseDeltaClassification& classification)
     {
-        assert(classification.kind == SparseDeltaKind::CARRY);
-        (void)classification;
         auto encoded = std::make_unique<CollectedData>(cid);
         auto& buf = encoded->getBuffer();
-        buf.append(Action::CARRY);
+        const auto action = sparseActionFromKind_(classification.kind);
+        buf.append(action);
+
+        switch (action)
+        {
+        case Action::CONTAINER_SWAP:
+            assert(classification.bin_index.isValid());
+            assert(!classification.payload.empty());
+            buf.append(classification.bin_index.getValue());
+            buf.append(classification.payload);
+            break;
+        case Action::CONTAINER_MULTI_SWAP:
+            assert(classification.bin_indices.size() >= 2);
+            assert(classification.bin_indices.size() == classification.payloads.size());
+            buf.append(static_cast<uint8_t>(classification.bin_indices.size()));
+            for (size_t i = 0; i < classification.bin_indices.size(); ++i)
+            {
+                buf.append(classification.bin_indices[i]);
+                buf.append(classification.payloads[i]);
+            }
+            break;
+        case Action::CARRY:
+            break;
+        default:
+            throw DBException("Unexpected sparse delta action");
+        }
+
         return encoded;
     }
 

--- a/include/simdb/apps/argos/CheckpointDeltas.hpp
+++ b/include/simdb/apps/argos/CheckpointDeltas.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "simdb/Exceptions.hpp"
+#include "simdb/utils/ValidValue.hpp"
 
 #include <cstdint>
 #include <iostream>
@@ -40,12 +41,16 @@ inline std::ostream& operator<<(std::ostream& os, ScalarDeltaKind kind)
 }
 
 //! Contiguous-container delta kinds.
-enum class ContigDeltaKind { CARRY, FULL };
+enum class ContigDeltaKind { CARRY, SWAP, MULTI_SWAP, FULL };
 
 //! Result of classifying a contig container transition.
 struct ContigDeltaClassification
 {
     ContigDeltaKind kind = ContigDeltaKind::FULL;
+    simdb::ValidValue<uint16_t> swap_index;
+    std::vector<char> payload;
+    std::vector<uint16_t> swap_indices;
+    std::vector<std::vector<char>> swap_payloads;
 };
 
 inline uint16_t countContigElements(const std::vector<std::vector<char>>& contig_bins)
@@ -85,16 +90,44 @@ inline ContigDeltaClassification classifyContigChange(const std::vector<std::vec
 
     if (curr_size == prev_size)
     {
+        ValidValue<uint16_t> changed_idx;
+        uint16_t num_changes = 0;
+        std::vector<uint16_t> changed_idxs;
         for (uint16_t i = 0; i < curr_size; ++i)
         {
             if (curr[i] != prev[i])
             {
-                result.kind = ContigDeltaKind::FULL;
-                return result;
+                changed_idxs.push_back(i);
+                changed_idx = i;
+                ++num_changes;
+                if (num_changes > 1)
+                {
+                    changed_idx.clearValid();
+                }
             }
         }
 
-        result.kind = ContigDeltaKind::CARRY;
+        if (num_changes == 0)
+        {
+            result.kind = ContigDeltaKind::CARRY;
+            return result;
+        }
+
+        if (num_changes == 1)
+        {
+            result.kind = ContigDeltaKind::SWAP;
+            result.swap_index = changed_idx.getValue();
+            result.payload = curr[changed_idx.getValue()];
+            return result;
+        }
+
+        result.kind = ContigDeltaKind::MULTI_SWAP;
+        result.swap_indices = std::move(changed_idxs);
+        result.swap_payloads.reserve(result.swap_indices.size());
+        for (const auto idx : result.swap_indices)
+        {
+            result.swap_payloads.push_back(curr[idx]);
+        }
         return result;
     }
 
@@ -108,6 +141,10 @@ inline std::ostream& operator<<(std::ostream& os, ContigDeltaKind kind)
     {
     case ContigDeltaKind::CARRY:
         return os << "CARRY";
+    case ContigDeltaKind::SWAP:
+        return os << "SWAP";
+    case ContigDeltaKind::MULTI_SWAP:
+        return os << "MULTI_SWAP";
     case ContigDeltaKind::FULL:
         return os << "FULL";
     }
@@ -115,12 +152,16 @@ inline std::ostream& operator<<(std::ostream& os, ContigDeltaKind kind)
 }
 
 //! Sparse-container delta kinds.
-enum class SparseDeltaKind { CARRY, FULL };
+enum class SparseDeltaKind { CARRY, SWAP, MULTI_SWAP, FULL };
 
 //! Result of classifying a sparse container transition.
 struct SparseDeltaClassification
 {
     SparseDeltaKind kind = SparseDeltaKind::FULL;
+    simdb::ValidValue<uint16_t> bin_index;
+    std::vector<char> payload;
+    std::vector<uint16_t> bin_indices;
+    std::vector<std::vector<char>> payloads;
 };
 
 inline uint16_t countSparseElements(const std::map<uint16_t, std::vector<char>>& sparse_bins)
@@ -158,6 +199,59 @@ inline SparseDeltaClassification classifySparseChange(const std::map<uint16_t, s
         return result;
     }
 
+    const auto curr_size = countSparseElements(curr);
+    const auto prev_size = countSparseElements(prev);
+    if (curr_size != prev_size)
+    {
+        result.kind = SparseDeltaKind::FULL;
+        return result;
+    }
+
+    std::vector<uint16_t> changed_idxs;
+    for (const auto& [prev_idx, prev_bytes] : prev)
+    {
+        if (auto it = curr.find(prev_idx); it != curr.end())
+        {
+            if (prev_bytes != it->second)
+            {
+                changed_idxs.push_back(prev_idx);
+            }
+        } else
+        {
+            result.kind = SparseDeltaKind::FULL;
+            return result;
+        }
+    }
+
+    for (const auto& [curr_idx, _] : curr)
+    {
+        if (prev.find(curr_idx) == prev.end())
+        {
+            result.kind = SparseDeltaKind::FULL;
+            return result;
+        }
+    }
+
+    if (changed_idxs.size() == 1)
+    {
+        result.kind = SparseDeltaKind::SWAP;
+        result.bin_index = changed_idxs[0];
+        result.payload = curr.at(changed_idxs[0]);
+        return result;
+    }
+
+    if (changed_idxs.size() >= 2)
+    {
+        result.kind = SparseDeltaKind::MULTI_SWAP;
+        result.bin_indices = std::move(changed_idxs);
+        result.payloads.reserve(result.bin_indices.size());
+        for (const auto idx : result.bin_indices)
+        {
+            result.payloads.push_back(curr.at(idx));
+        }
+        return result;
+    }
+
     result.kind = SparseDeltaKind::FULL;
     return result;
 }
@@ -168,6 +262,10 @@ inline std::ostream& operator<<(std::ostream& os, SparseDeltaKind kind)
     {
     case SparseDeltaKind::CARRY:
         return os << "CARRY";
+    case SparseDeltaKind::SWAP:
+        return os << "SWAP";
+    case SparseDeltaKind::MULTI_SWAP:
+        return os << "MULTI_SWAP";
     case SparseDeltaKind::FULL:
         return os << "FULL";
     }

--- a/include/simdb/apps/argos/CheckpointEncodings.hpp
+++ b/include/simdb/apps/argos/CheckpointEncodings.hpp
@@ -35,6 +35,8 @@
  *                                           (`shouldRefreshAbsentCid_`).
  * CARRY                    All              Payload unchanged since the prior data checkpoint and none of the FULL forcing
  *                                           rules apply.
+ * CONTAINER_SWAP           Contig, Sparse   Same occupied count; exactly one bin's value changed (same index).
+ * CONTAINER_MULTI_SWAP     Contig, Sparse   Same occupied count; two or more bin values changed with no adds or removes.
  * \endverbatim
  *
  * Scalars only ever emit CLOSED, FULL, or CARRY.
@@ -61,6 +63,8 @@
  * | FULL (scalar)          | [scalar bytes]                                         |
  * | FULL (contig)          | [count][bin bytes]..[bin bytes]                        |
  * | FULL (sparse)          | [count][bin idx][bin bytes]..[bin idx][bin bytes]      |
+ * | CONTAINER_SWAP         | [bin idx][bin bytes]                                   |
+ * | CONTAINER_MULTI_SWAP   | [count][bin idx][bin bytes]..[bin idx][bin bytes]      |
  *
  * \par Related implementation files
  *


### PR DESCRIPTION
Classify same-size contig and sparse value changes as single- or multi-bin swaps and emit the shared tier-2 wire format. Size changes and key add/remove still fall back to FULL.