### PR TITLE
Add contig FIFO arrive/depart delta encodings

### DIFF
--- a/include/simdb/apps/argos/Checkpoint.hpp
+++ b/include/simdb/apps/argos/Checkpoint.hpp
@@ -23,6 +23,9 @@ enum class Action : uint8_t {
 
     CONTAINER_SWAP = 0x10,
     CONTAINER_MULTI_SWAP = 0x11,
+
+    CONTIG_ARRIVE = 0x20,
+    CONTIG_DEPART = 0x21,
 };
 
 //! \class CollectableCheckpoint
@@ -313,6 +316,10 @@ private:
             return Action::CONTAINER_SWAP;
         case ContigDeltaKind::MULTI_SWAP:
             return Action::CONTAINER_MULTI_SWAP;
+        case ContigDeltaKind::ARRIVE:
+            return Action::CONTIG_ARRIVE;
+        case ContigDeltaKind::DEPART:
+            return Action::CONTIG_DEPART;
         case ContigDeltaKind::FULL:
             break;
         }
@@ -380,6 +387,12 @@ private:
             }
             break;
         case Action::CARRY:
+            break;
+        case Action::CONTIG_ARRIVE:
+            assert(!classification.payload.empty());
+            buf.append(classification.payload);
+            break;
+        case Action::CONTIG_DEPART:
             break;
         default:
             throw DBException("Unexpected contig delta action");

--- a/include/simdb/apps/argos/CheckpointDeltas.hpp
+++ b/include/simdb/apps/argos/CheckpointDeltas.hpp
@@ -41,7 +41,7 @@ inline std::ostream& operator<<(std::ostream& os, ScalarDeltaKind kind)
 }
 
 //! Contiguous-container delta kinds.
-enum class ContigDeltaKind { CARRY, SWAP, MULTI_SWAP, FULL };
+enum class ContigDeltaKind { CARRY, SWAP, MULTI_SWAP, ARRIVE, DEPART, FULL };
 
 //! Result of classifying a contig container transition.
 struct ContigDeltaClassification
@@ -131,6 +131,43 @@ inline ContigDeltaClassification classifyContigChange(const std::vector<std::vec
         return result;
     }
 
+    if (curr_size == prev_size + 1)
+    {
+        bool arrive = true;
+        for (uint16_t i = 0; i < prev_size; ++i)
+        {
+            if (curr[i] != prev[i])
+            {
+                arrive = false;
+                break;
+            }
+        }
+
+        if (arrive)
+        {
+            result.kind = ContigDeltaKind::ARRIVE;
+            result.payload = curr[curr_size - 1];
+            return result;
+        }
+    } else if (prev_size == curr_size + 1)
+    {
+        bool depart = true;
+        for (uint16_t i = 0; i < curr_size; ++i)
+        {
+            if (curr[i] != prev[i + 1])
+            {
+                depart = false;
+                break;
+            }
+        }
+
+        if (depart)
+        {
+            result.kind = ContigDeltaKind::DEPART;
+            return result;
+        }
+    }
+
     result.kind = ContigDeltaKind::FULL;
     return result;
 }
@@ -145,6 +182,10 @@ inline std::ostream& operator<<(std::ostream& os, ContigDeltaKind kind)
         return os << "SWAP";
     case ContigDeltaKind::MULTI_SWAP:
         return os << "MULTI_SWAP";
+    case ContigDeltaKind::ARRIVE:
+        return os << "ARRIVE";
+    case ContigDeltaKind::DEPART:
+        return os << "DEPART";
     case ContigDeltaKind::FULL:
         return os << "FULL";
     }

--- a/include/simdb/apps/argos/CheckpointEncodings.hpp
+++ b/include/simdb/apps/argos/CheckpointEncodings.hpp
@@ -37,6 +37,8 @@
  *                                           rules apply.
  * CONTAINER_SWAP           Contig, Sparse   Same occupied count; exactly one bin's value changed (same index).
  * CONTAINER_MULTI_SWAP     Contig, Sparse   Same occupied count; two or more bin values changed with no adds or removes.
+ * CONTIG_ARRIVE            Contig only      Size +1; prefix unchanged; one new element appended at the tail.
+ * CONTIG_DEPART            Contig only      Size -1; front pop — `curr[i] == prev[i+1]` for all remaining indices.
  * \endverbatim
  *
  * Scalars only ever emit CLOSED, FULL, or CARRY.
@@ -65,6 +67,8 @@
  * | FULL (sparse)          | [count][bin idx][bin bytes]..[bin idx][bin bytes]      |
  * | CONTAINER_SWAP         | [bin idx][bin bytes]                                   |
  * | CONTAINER_MULTI_SWAP   | [count][bin idx][bin bytes]..[bin idx][bin bytes]      |
+ * | CONTIG_ARRIVE          | [pushed bytes]                                         |
+ * | CONTIG_DEPART          |                                                        |
  *
  * \par Related implementation files
  *


### PR DESCRIPTION
Classify tail-append and front-pop contig transitions as CONTIG_ARRIVE and CONTIG_DEPART. Other size changes still fall back to FULL until MIMO support lands in a follow-on PR.