### PR TITLE
Add contig bookends and MIMO delta encodings

### DIFF
--- a/include/simdb/apps/argos/Checkpoint.hpp
+++ b/include/simdb/apps/argos/Checkpoint.hpp
@@ -26,6 +26,8 @@ enum class Action : uint8_t {
 
     CONTIG_ARRIVE = 0x20,
     CONTIG_DEPART = 0x21,
+    CONTIG_BOOKENDS = 0x22,
+    CONTIG_MIMO = 0x23,
 };
 
 //! \class CollectableCheckpoint
@@ -320,6 +322,10 @@ private:
             return Action::CONTIG_ARRIVE;
         case ContigDeltaKind::DEPART:
             return Action::CONTIG_DEPART;
+        case ContigDeltaKind::BOOKENDS:
+            return Action::CONTIG_BOOKENDS;
+        case ContigDeltaKind::MIMO:
+            return Action::CONTIG_MIMO;
         case ContigDeltaKind::FULL:
             break;
         }
@@ -389,8 +395,17 @@ private:
         case Action::CARRY:
             break;
         case Action::CONTIG_ARRIVE:
+        case Action::CONTIG_BOOKENDS:
             assert(!classification.payload.empty());
             buf.append(classification.payload);
+            break;
+        case Action::CONTIG_MIMO:
+            buf.append(classification.depart_count);
+            buf.append(classification.arrive_count);
+            for (const auto& arrive_payload : classification.arrive_payloads)
+            {
+                buf.append(arrive_payload);
+            }
             break;
         case Action::CONTIG_DEPART:
             break;

--- a/include/simdb/apps/argos/CheckpointDeltas.hpp
+++ b/include/simdb/apps/argos/CheckpointDeltas.hpp
@@ -41,7 +41,7 @@ inline std::ostream& operator<<(std::ostream& os, ScalarDeltaKind kind)
 }
 
 //! Contiguous-container delta kinds.
-enum class ContigDeltaKind { CARRY, SWAP, MULTI_SWAP, ARRIVE, DEPART, FULL };
+enum class ContigDeltaKind { CARRY, SWAP, MULTI_SWAP, BOOKENDS, ARRIVE, DEPART, MIMO, FULL };
 
 //! Result of classifying a contig container transition.
 struct ContigDeltaClassification
@@ -49,6 +49,9 @@ struct ContigDeltaClassification
     ContigDeltaKind kind = ContigDeltaKind::FULL;
     simdb::ValidValue<uint16_t> swap_index;
     std::vector<char> payload;
+    uint8_t depart_count = 0;
+    uint8_t arrive_count = 0;
+    std::vector<std::vector<char>> arrive_payloads;
     std::vector<uint16_t> swap_indices;
     std::vector<std::vector<char>> swap_payloads;
 };
@@ -68,6 +71,25 @@ inline uint16_t countContigElements(const std::vector<std::vector<char>>& contig
     }
     assert(count <= UINT16_MAX);
     return count;
+}
+
+inline bool contigPrefixMatchesAfterDepart(const std::vector<std::vector<char>>& prev,
+                                           const std::vector<std::vector<char>>& curr, uint16_t prev_size,
+                                           uint16_t curr_size, uint16_t depart_count)
+{
+    const auto overlap = static_cast<uint16_t>(prev_size - depart_count);
+    if (overlap + static_cast<uint16_t>(curr_size - overlap) != curr_size)
+    {
+        return false;
+    }
+    for (uint16_t i = 0; i < overlap; ++i)
+    {
+        if (curr[i] != prev[i + depart_count])
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 //! Classify how a contiguous container changed between consecutive collections.
@@ -121,6 +143,26 @@ inline ContigDeltaClassification classifyContigChange(const std::vector<std::vec
             return result;
         }
 
+        if (curr_size > 0)
+        {
+            bool bookends = true;
+            for (size_t i = 0; i + 1 < curr_size; ++i)
+            {
+                if (curr[i] != prev[i + 1])
+                {
+                    bookends = false;
+                    break;
+                }
+            }
+
+            if (bookends)
+            {
+                result.kind = ContigDeltaKind::BOOKENDS;
+                result.payload = curr[curr_size - 1];
+                return result;
+            }
+        }
+
         result.kind = ContigDeltaKind::MULTI_SWAP;
         result.swap_indices = std::move(changed_idxs);
         result.swap_payloads.reserve(result.swap_indices.size());
@@ -168,6 +210,41 @@ inline ContigDeltaClassification classifyContigChange(const std::vector<std::vec
         }
     }
 
+    for (uint16_t depart_count = 0; depart_count <= prev_size; ++depart_count)
+    {
+        const int64_t arrive_count64 = static_cast<int64_t>(curr_size) - static_cast<int64_t>(prev_size) + depart_count;
+        if (arrive_count64 < 0 || arrive_count64 > UINT8_MAX)
+        {
+            continue;
+        }
+
+        const auto arrive_count = static_cast<uint8_t>(arrive_count64);
+        if (depart_count + arrive_count <= 1)
+        {
+            continue;
+        }
+        if (depart_count == 1 && arrive_count == 1 && curr_size == prev_size)
+        {
+            continue;
+        }
+
+        if (!contigPrefixMatchesAfterDepart(prev, curr, prev_size, curr_size, depart_count))
+        {
+            continue;
+        }
+
+        const auto overlap = static_cast<uint16_t>(prev_size - depart_count);
+        result.kind = ContigDeltaKind::MIMO;
+        result.depart_count = static_cast<uint8_t>(depart_count);
+        result.arrive_count = arrive_count;
+        result.arrive_payloads.reserve(arrive_count);
+        for (uint8_t j = 0; j < arrive_count; ++j)
+        {
+            result.arrive_payloads.push_back(curr[overlap + j]);
+        }
+        return result;
+    }
+
     result.kind = ContigDeltaKind::FULL;
     return result;
 }
@@ -182,10 +259,14 @@ inline std::ostream& operator<<(std::ostream& os, ContigDeltaKind kind)
         return os << "SWAP";
     case ContigDeltaKind::MULTI_SWAP:
         return os << "MULTI_SWAP";
+    case ContigDeltaKind::BOOKENDS:
+        return os << "BOOKENDS";
     case ContigDeltaKind::ARRIVE:
         return os << "ARRIVE";
     case ContigDeltaKind::DEPART:
         return os << "DEPART";
+    case ContigDeltaKind::MIMO:
+        return os << "MIMO";
     case ContigDeltaKind::FULL:
         return os << "FULL";
     }

--- a/include/simdb/apps/argos/CheckpointEncodings.hpp
+++ b/include/simdb/apps/argos/CheckpointEncodings.hpp
@@ -39,6 +39,11 @@
  * CONTAINER_MULTI_SWAP     Contig, Sparse   Same occupied count; two or more bin values changed with no adds or removes.
  * CONTIG_ARRIVE            Contig only      Size +1; prefix unchanged; one new element appended at the tail.
  * CONTIG_DEPART            Contig only      Size -1; front pop — `curr[i] == prev[i+1]` for all remaining indices.
+ * CONTIG_BOOKENDS          Contig only      Same size; shift-left with new tail — `curr[i] == prev[i+1]` for all but the
+ *                                           last index (last bin is a new value).
+ * CONTIG_MIMO              Contig only      FIFO MIMO: D elements depart from the front and A arrive at the tail; after
+ *                                           the depart shift, prefixes match; `D + A > 1`; not a simpler single-op pattern
+ *                                           (e.g. not 1 depart + 1 arrive at same size).
  * \endverbatim
  *
  * Scalars only ever emit CLOSED, FULL, or CARRY.
@@ -69,6 +74,8 @@
  * | CONTAINER_MULTI_SWAP   | [count][bin idx][bin bytes]..[bin idx][bin bytes]      |
  * | CONTIG_ARRIVE          | [pushed bytes]                                         |
  * | CONTIG_DEPART          |                                                        |
+ * | CONTIG_BOOKENDS        | [pushed bytes]                                         |
+ * | CONTIG_MIMO            | [num popped][num pushed][pushed bytes]..[pushed bytes] |
  *
  * \par Related implementation files
  *


### PR DESCRIPTION
Detect same-size shift-left-with-new-tail patterns as CONTIG_BOOKENDS before falling back to CONTAINER_MULTI_SWAP, and classify combined front depart / tail arrive transitions as CONTIG_MIMO.